### PR TITLE
Fix spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install @maplibre/ngx-maplibre-gl maplibre-gl
 yarn add @maplibre/ngx-maplibre-gl maplibre-gl
 ```
 
-There might be a beed to add the following configuration to `tsconfig.json` file
+There might be a need to add the following configuration to `tsconfig.json` file
 
 ```
 "compilerOptions": {


### PR DESCRIPTION
Spelling mistake fix
`beed -> need` in README